### PR TITLE
Support multiple sets of samples in analog measurers

### DIFF
--- a/voltageMinMax/voltage_min_max.py
+++ b/voltageMinMax/voltage_min_max.py
@@ -17,12 +17,13 @@ class VoltageMinMaxMeasurer(AnalogMeasurer):
         self.minimum_value = None
 
         if MINIMUM_V in self.requested_measurements:
-            self.minimum_value = 0
+            self.minimum_value = math.inf
 
         self.maximum_value = None
 
         if MAXIMUM_V in self.requested_measurements:
-            self.maximum_value = 0
+            self.maximum_value = -math.inf
+
     # This method will be called one or more times per measurement with batches of data
     # data has the following interface
     #   * Iterate over to get Voltage values, one per sample
@@ -31,11 +32,11 @@ class VoltageMinMaxMeasurer(AnalogMeasurer):
     def process_data(self, data):
         if self.minimum_value is not None:
             min_val = numpy.amin(data.samples)
-            self.minimum_value = min_val
+            self.minimum_value = min(min_val, self.minimum_value)
 
         if self.maximum_value is not None:
             max_val = numpy.amax(data.samples)
-            self.maximum_value = max_val
+            self.maximum_value = max(max_val, self.maximum_value)
 
     # This method is called after all the relevant data has been passed to `process_data`
     # It returns a dictionary of the request_measurements values

--- a/voltagePeakToPeak/voltage_peak_to_peak.py
+++ b/voltagePeakToPeak/voltage_peak_to_peak.py
@@ -13,10 +13,10 @@ class VoltagePeakToPeak(AnalogMeasurer):
     def __init__(self, requested_measurements):
         super().__init__(requested_measurements)
 
-        self.peak_value = None
-        
-        if PEAK_TO_PEAK in self.requested_measurements:
-            self.peak_value = 0
+        self.measure_peak = PEAK_TO_PEAK in self.requested_measurements
+        if self.measure_peak:
+            self.minimum_value = math.inf
+            self.maximum_value = -math.inf
 
     # This method will be called one or more times per measurement with batches of data
     # data has the following interface
@@ -24,18 +24,18 @@ class VoltagePeakToPeak(AnalogMeasurer):
     #   * `data.samples` is a numpy array of float32 voltages, one for each sample
     #   * `data.sample_count` is the number of samples (same value as `len(data.samples)` but more efficient if you don't need a numpy array)
     def process_data(self, data):
-        if self.peak_value is not None:
+        if self.measure_peak:
             min_val = numpy.amin(data.samples)
-            self.minimum_value = min_val
+            self.minimum_value = min(min_val, self.minimum_value)
             max_val = numpy.amax(data.samples)
-            self.maximum_value = max_val
+            self.maximum_value = max(max_val, self.maximum_value)
 
     # This method is called after all the relevant data has been passed to `process_data`
     # It returns a dictionary of the request_measurements values
     def measure(self):
         values = {}
 
-        if self.peak_value is not None:
+        if self.measure_peak:
             values[PEAK_TO_PEAK] = self.maximum_value - self.minimum_value
 
         return values


### PR DESCRIPTION
Closes #1 

This relies on the documented fact that `process_data()` "ill be called *one* or more times per measurement with batches of data" -- if called zero times, the infinity/negative infinity values will be returned. This seems reasonable, since 1) that behavior is documented, and 2) the peak-to-peak measurement would already have errors if `process_data()` was called zero times.